### PR TITLE
Fixes iOS 11 unrecognized selector crash

### DIFF
--- a/ios/Classes/SwiftHomeIndicatorPlugin.swift
+++ b/ios/Classes/SwiftHomeIndicatorPlugin.swift
@@ -23,7 +23,9 @@ class HomeIndicatorAwareFlutterViewController : FlutterViewController {
     if (newValue != HomeIndicatorAwareFlutterViewController.hidingHomeIndicator) {
       HomeIndicatorAwareFlutterViewController.hidingHomeIndicator = newValue
       if #available(iOS 11.0, *) {
-        setNeedsUpdateOfHomeIndicatorAutoHidden()
+        if responds(to: #selector(setNeedsUpdateOfHomeIndicatorAutoHidden)) {
+            setNeedsUpdateOfHomeIndicatorAutoHidden()
+        }
       } else {
         // Fallback on earlier versions: do nothing
       }


### PR DESCRIPTION
When running on a device with iOS 11, I found that our app would crash with the following error:

`2020-05-13 14:00:16.294573-0500 Runner[736:197171] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[home_indicator.HomeIndicatorAwareFlutterViewController setNeedsUpdateOfHomeIndicatorAutoHidden]: unrecognized selector sent to instance 0x10a812e00'`

Wrapping the `setNeedsUpdateOfHomeIndicatorAutoHidden()` call with a `responds(to: #selector(setNeedsUpdateOfHomeIndicatorAutoHidden)` check prevents the crash from happening while maintaining the proper behavior across iOS versions.

More info about this particular crash can be found at https://github.com/lionheart/openradar-mirror/issues/18762.

Thanks for making this, really useful in an app we're currently working on! 🤗